### PR TITLE
Fix definition of BEGIN_C_DECLS in C mode.

### DIFF
--- a/src/c-inner-main.h
+++ b/src/c-inner-main.h
@@ -6,7 +6,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 

--- a/src/c-interface-gtk-widgets.h
+++ b/src/c-interface-gtk-widgets.h
@@ -76,7 +76,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/c-interface-preferences.h
+++ b/src/c-interface-preferences.h
@@ -6,7 +6,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/c-interface-refmac.h
+++ b/src/c-interface-refmac.h
@@ -76,7 +76,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/c-interface.h
+++ b/src/c-interface.h
@@ -76,7 +76,7 @@ p  So we need to have this function external for c++ linking.
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/drag-and-drop.hh
+++ b/src/drag-and-drop.hh
@@ -3,7 +3,7 @@
 #define BEGIN_C_DECLS extern "C" {
 #define END_C_DECLS }
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 

--- a/src/generic-display-objects-c.h
+++ b/src/generic-display-objects-c.h
@@ -6,7 +6,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/gtk-widget-conversion-utils.h
+++ b/src/gtk-widget-conversion-utils.h
@@ -6,7 +6,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/mmcif-sfs-to-mtz-main.cc
+++ b/src/mmcif-sfs-to-mtz-main.cc
@@ -8,7 +8,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/rama_mousey.hh
+++ b/src/rama_mousey.hh
@@ -8,7 +8,7 @@
 #define BEGIN_C_DECLS extern "C" {
 #define END_C_DECLS }
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS
 #endif
 

--- a/src/read-cif.h
+++ b/src/read-cif.h
@@ -6,7 +6,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/read-phs.h
+++ b/src/read-phs.h
@@ -25,7 +25,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 #endif /* BEGIN_C_DECLS */

--- a/src/trackball.h
+++ b/src/trackball.h
@@ -58,7 +58,7 @@
 #define END_C_DECLS }
 
 #else
-#define BEGIN_C_DECLS extern
+#define BEGIN_C_DECLS
 #define END_C_DECLS     
 #endif
 


### PR DESCRIPTION
Remove an errant 'extern' from these definitions
to fix compile errors when building C (rather than
C++) code.