### PR TITLE
Do not use : etc in coot-backup/ file names

### DIFF
--- a/src/molecule-class-info.cc
+++ b/src/molecule-class-info.cc
@@ -6651,30 +6651,20 @@ molecule_class_info_t::save_molecule_filename(const std::string &dir) {
       // convert "/" to "_"
       int slen = clean_name.length();
       for (int i=0; i<slen; i++)
-#if defined(__WIN32__) || defined(__CYGWIN__) || defined(WINDOWS_MINGW)
 // BL says: we change /, \ and : to _ in windows
          if (clean_name[i] == '/' || clean_name[i] == '\\'
                              || clean_name[i] == ':')
             clean_name[i] = '_';
-#else
-	 if (clean_name[i] == '/')
-	    clean_name[i] = '_';
-#endif // win32 things
 
       time_string += clean_name;
       time_string += "_";
 
       // add in the time component:
 
-#if defined(__CYGWIN__) || defined(_MSC_VER)
-
-      // but not if we are in windows:
-
-#else
       time_t t;
       time(&t);
       char *chars_time = ctime(&t);
-#ifdef WINDOWS_MINGW
+
 // BL says: why not? We can fix this. I show you how it's done in MINGW:
 // dunno if it works in other win32 systems. Havent checked
 // we just convert the : to _
@@ -6683,9 +6673,8 @@ molecule_class_info_t::save_molecule_filename(const std::string &dir) {
              chars_time[i] = '_';
          }
       }
-#endif // MINGW
+
       time_string += chars_time;
-#endif // other WIN32
 
       // strip off the trailing newline:
       slen = time_string.length();
@@ -6698,18 +6687,13 @@ molecule_class_info_t::save_molecule_filename(const std::string &dir) {
 	 if (time_string[i] == ' ')
 	    time_string[i] = '_';
 
-#if defined(__WIN32__) || defined(__CYGWIN__) || defined(WINDOWS_MINGW) || defined(_MSC_VER)
-
       // convert : to underscores in windows
       //
-#ifndef WINDOWS_MINGW
       // BL say: nonsense since we would transform the directory C: here.
       // we have done it before already
       for (int i=0; i<time_string.length(); i++)
 	 if (time_string[i] == ':')
 	    time_string[i] = '_';
-#endif // MINGW
-#endif // other win32
 
       time_string += "_modification_";
 


### PR DESCRIPTION
Even if not Windows, windows-incompatible file name cannot be used (for example) on the cifs/smb mounted filesystems.