### PR TITLE
Fix compilation and linking against recent versions of Python

### DIFF
--- a/macros/with-python.m4
+++ b/macros/with-python.m4
@@ -75,7 +75,7 @@ if test x$with_python != x; then
       # PYTHON_LIBS="-L/h/paule/build/lib/python2.2/config -lpython2.2 -lutil"
       config_dir=`$PYTHON -c "import sys; print(sys.prefix + '/$acl_libdirstem/python' + sys.version[[:3]] + '/config')"`
       # echo  ======== config_dir: $config_dir
-      PYTHON_LIBS_PRE="`$PYTHON_CONFIG --ldflags`"
+      PYTHON_LIBS_PRE="`$PYTHON_CONFIG --ldflags --embed`"
    
       # extra hacking so that -ldl appears after -lpython2.x (needed
       # for correct linking on some systems)

--- a/src/c-interface.cc
+++ b/src/c-interface.cc
@@ -6083,7 +6083,7 @@ PyObject *symmetry_operators_py(int imol) {
 	 std::cout << "WARNING:: in symmetry_operators_py() null space group " << std::endl;
       }
    }
-   if PyBool_Check(o) {
+   if (PyBool_Check(o)) {
      Py_INCREF(o);
    }
    return o;
@@ -6109,7 +6109,7 @@ symmetry_operators_to_xHM_py(PyObject *symmetry_operators) {
    clipper::Spacegroup sg = py_symop_strings_to_space_group(symmetry_operators);
    if (! sg.is_null())
       o = myPyString_FromString(sg.symbol_hm().c_str());
-   if PyBool_Check(o) {
+   if (PyBool_Check(o)) {
      Py_INCREF(o);
    }
    return o;


### PR DESCRIPTION
This pull request fixes compilation against recent versions of Python (checked with Python 3.9) and works around a change in the behaviour of `python-config` that will cause linking to fail against Python 3.8 and newer.

This closes issue #31. 