### PR TITLE
Use readlink that works for non-GNU systems too

### DIFF
--- a/src/coot.in
+++ b/src/coot.in
@@ -39,13 +39,15 @@ function check_for_no_graphics {
 current_exe_dir=$(dirname $0)
 systype=$(uname)
 
-if [ $systype = Darwin ] ; then
-    COOT_PREFIX="$(cd "$(dirname "$current_exe_dir")" 2>/dev/null && pwd)"
-else
-    unlinked_exe=$(readlink -f $0)
-    unlinked_exe_dir=$(dirname $unlinked_exe)
-    COOT_PREFIX=$(dirname $unlinked_exe_dir)
-fi
+# ht: https://stackoverflow.com/a/246128
+SOURCE=${BASH_SOURCE[0]}
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$(cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd)
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+COOT_BIN_PREFIX=$(cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd)
+COOT_PREFIX=$(dirname $COOT_BIN_PREFIX)
 # echo COOT_PREFIX is $COOT_PREFIX
 
 


### PR DESCRIPTION
Homebrew works through a lot of symlinks, so the coot executable ends up a long way from coot-bin, not just one symlink away.

On most Linux distros, GNU readlink has the `-f` flag, is able to recursively search for the target of the symlink.
macOS doesn't have GNU readlink, so it's missing the `-f` flag.
I shamelessly yoinked some code from https://stackoverflow.com/a/246128 which manually handles the recursion.

I believe (though have no proof) that this should work on Linux --- if it does though, I'd consider it an improvement?