### PR TITLE
Fix `export_model_molecule_as_gltf` and `get_diff_diff_map_peaks`

### DIFF
--- a/api/molecules_container.cc
+++ b/api/molecules_container.cc
@@ -2415,10 +2415,10 @@ molecules_container_t::get_diff_diff_map_peaks(int imol_map_fofc,
 
    clipper::Coord_orth screen_centre(screen_centre_x, screen_centre_y, screen_centre_z); // also, is this used in this function?
    std::vector<std::pair<clipper::Coord_orth, float> > v;
-   if (is_valid_model_molecule(imol_map_fofc)) {
+   if (is_valid_map_molecule(imol_map_fofc)) {
       v = molecules[imol_map_fofc].get_updating_maps_diff_diff_map_peaks(screen_centre);
    } else {
-      std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid model molecule " << imol_map_fofc << std::endl;
+      std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid map molecule " << imol_map_fofc << std::endl;
    }
    return v;
 

--- a/api/molecules_container.cc
+++ b/api/molecules_container.cc
@@ -5008,7 +5008,7 @@ molecules_container_t::export_map_molecule_as_gltf(int imol, const std::string &
    if (is_valid_map_molecule(imol)) {
       molecules[imol].export_map_molecule_as_gltf(file_name);
    } else {
-      std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid model molecule " << imol << std::endl;
+      std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid map molecule " << imol << std::endl;
    }
 
 
@@ -5018,7 +5018,7 @@ molecules_container_t::export_map_molecule_as_gltf(int imol, const std::string &
 void
 molecules_container_t::export_model_molecule_as_gltf(int imol, const std::string &file_name) const {
 
-   if (is_valid_map_molecule(imol)) {
+   if (is_valid_model_molecule(imol)) {
       molecules[imol].export_model_molecule_as_gltf(file_name);
    } else {
       std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid model molecule " << imol << std::endl;


### PR DESCRIPTION
Currently `molecules_container_t::export_model_molecule_as_gltf` does not work as it uses `molecules_container_t::is_valid_map_molecule` to test whether the input imol is valid. This update fixes the problem and updates the debug message.