### PR TITLE
missing FFTW2_LIBS in MoleculesToTriangles/CXXSurface/Makefile.am

### DIFF
--- a/MoleculesToTriangles/CXXSurface/Makefile.am
+++ b/MoleculesToTriangles/CXXSurface/Makefile.am
@@ -17,7 +17,7 @@ libMoleculesToTrianglesCXXSurface_la_SOURCES=CXXCircle.cpp CXXCircleNode.cpp \
 	CXXCreator.cpp CXXSpace.cpp CXXFFTSolventMap.cpp CXXChargeTable.cpp CXXException.cpp \
 	CXXUtils.cpp CXXBall.cpp CXXSurfaceMaker.cpp
 
-libMoleculesToTrianglesCXXSurface_la_LIBADD = $(CLIPPER_LIBS) $(MMDB_LIBS)
+libMoleculesToTrianglesCXXSurface_la_LIBADD = $(CLIPPER_LIBS) $(FFTW2_LIBS) $(MMDB_LIBS)
 
 libMoleculesToTrianglesCXXSurface_la_LDFLAGS=$(SHARED_LDFLAGS)
 


### PR DESCRIPTION
building coot using a clipper without fftw2, e.g. from the openSUSE:Science project, reveals a missing FFTW2_LIBS in the link rule of MoleculesToTriangles/CXXSurface/Makefile.am