### PR TITLE
missing include files in coot-1.1.09.tar.gz

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -48,7 +48,7 @@ phi-psi-prob.hh          saved-strand-info.hh       simple-molecule.hh          
 generic-3d-lines.hh      cell.hh                    coot-simple-molecule.hh                \
 api-cell.hh              bond-colour.hh             make-instanced-graphical-bonds.hh      \
 symmetry-info.hh         instancing.hh              merge-molecule-results-info-t.hh       \
-coot-molecule-bonds.hh   clipper-ccp4-map-file-wrapper.hh blender-mesh.hh plain-atom-overlap.hh
+coot-molecule-bonds.hh   clipper-ccp4-map-file-wrapper.hh blender-mesh.hh plain-atom-overlap.hh lsq-results.hh
 
 lib_LTLIBRARIES=libcoot-api.la
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -33,7 +33,7 @@ lib_LTLIBRARIES=libcoot-utils.la
 
 pkginclude_HEADERS = coot-utils.hh coot-fasta.hh dodec.hh win-compat.hh ctpl_stl.h ctpl.h \
 	pir-alignment.hh align-utils.hh split-indices.hh radix.hh logging.hh insertion-sort.hh \
-	backward.hpp colour-holder.hh setup-syminfo.hh
+	backward.hpp colour-holder.hh setup-syminfo.hh xdg-base.hh
 
 pkgincludedir = $(includedir)/coot/utils
 


### PR DESCRIPTION
though there is no github tag (yet ?)  there is a commit "Release 1.1.09"  - and there is a coot-1.1.09.tar.gz on www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/source/releases - but that coot-1.1.09.tar.gz fails to build as needed include files api/lsq-results.hh and utils/xdg-base.hh are not in the tar.gz file.

the commit from this PR might help to fix the tar.gz file ?