### PR TITLE
Fix typo represenation/representation in a number of files

### DIFF
--- a/api/coot-molecule.cc
+++ b/api/coot-molecule.cc
@@ -4422,7 +4422,7 @@ coot::molecule_t::export_model_molecule_as_gltf(const std::string &mode,
 }
 
 void
-coot::molecule_t::export_molecular_represenation_as_gltf(const std::string &atom_selection_cid,
+coot::molecule_t::export_molecular_representation_as_gltf(const std::string &atom_selection_cid,
                                                          const std::string &colour_scheme, const std::string &style,
                                                          int secondary_structure_usage_flag,
                                                          const std::string &file_name) {

--- a/api/coot-molecule.hh
+++ b/api/coot-molecule.hh
@@ -771,7 +771,7 @@ namespace coot {
                                          const std::string &file_name);
 
       // this is the ribbons and surfaces API
-      void export_molecular_represenation_as_gltf(const std::string &atom_selection_cid,
+      void export_molecular_representation_as_gltf(const std::string &atom_selection_cid,
                                                   const std::string &colour_scheme,
                                                   const std::string &style,
                                                   int secondary_structure_usage_flag,

--- a/api/molecules-container.cc
+++ b/api/molecules-container.cc
@@ -5478,13 +5478,13 @@ molecules_container_t::export_model_molecule_as_gltf(int imol,
 }
 
 void
-molecules_container_t::export_molecular_represenation_as_gltf(int imol, const std::string &atom_selection_cid,
+molecules_container_t::export_molecular_representation_as_gltf(int imol, const std::string &atom_selection_cid,
                                                               const std::string &colour_scheme, const std::string &style,
                                                               int secondary_structure_usage_flag,
                                                               const std::string &file_name) {
 
    if (is_valid_model_molecule(imol)) {
-      molecules[imol].export_molecular_represenation_as_gltf(atom_selection_cid, colour_scheme, style,
+      molecules[imol].export_molecular_representation_as_gltf(atom_selection_cid, colour_scheme, style,
                                                              secondary_structure_usage_flag, file_name);
    } else {
       std::cout << "WARNING:: " << __FUNCTION__ << "(): not a valid model molecule " << imol << std::endl;

--- a/dnotes
+++ b/dnotes
@@ -1038,15 +1038,15 @@ Wed Dec  5 14:13:31 GMT 2007
 
     Particular alt confs cannot be selected for.
 
-    Questions:  How shall we create new represenations for this molecule?
+    Questions:  How shall we create new representations for this molecule?
 
     // return
-    int add_representation imol represenation-spec
+    int add_representation imol representation-spec
 
     // used by GUI
-    undisplay_represenation imol respresentation-number
+    undisplay_representation imol respresentation-number
 
-    undisplay_represenation imol residue_spec
+    undisplay_representation imol residue_spec
     which needs to be unambiguated. Test in this order:
 
      o Was there a line_representation that has that residue_spec?

--- a/dnotes-2008
+++ b/dnotes-2008
@@ -4216,15 +4216,15 @@ Wed Dec  5 14:13:31 GMT 2007
 
     Particular alt confs cannot be selected for.
 
-    Questions:  How shall we create new represenations for this molecule?
+    Questions:  How shall we create new representations for this molecule?
 
     // return 
-    int add_representation imol represenation-spec
+    int add_representation imol representation-spec
 
     // used by GUI
-    undisplay_represenation imol respresentation-number
+    undisplay_representation imol respresentation-number
 
-    undisplay_represenation imol residue_spec
+    undisplay_representation imol residue_spec
     which needs to be unambiguated. Test in this order:
 
      o Was there a line_representation that has that residue_spec?

--- a/happy-coot-diary.html
+++ b/happy-coot-diary.html
@@ -357,7 +357,7 @@ Then coot build dependencies...
     variables/functions/classes out out ostensibly lower-level classes
     (e.g. those to do with storing, representing and mapulating
     molecules and maps).  However, when making display lists (a
-    molecule represenation issue, we need to know about the GL context
+    molecule representation issue, we need to know about the GL context
     state (a graphics issue) so the hierarchy was inverted in this
     case. Because of this, I had been doing a
     "draw_main_graphics_window()" then

--- a/src/c-interface.cc
+++ b/src/c-interface.cc
@@ -3274,7 +3274,7 @@ void set_default_bond_thickness(int t) {
 
 }
 
-/*! \brief set the default represenation type (default 1).*/
+/*! \brief set the default representation type (default 1).*/
 void set_default_representation_type(int type) {
    graphics_info_t g;
    g.default_bonds_box_type = type;

--- a/src/molecule-class-info.cc
+++ b/src/molecule-class-info.cc
@@ -3239,7 +3239,7 @@ molecule_class_info_t::add_additional_representation(int representation_type,
 
 // representation_number should be an unsigned int.
 int
-molecule_class_info_t::adjust_additional_representation(int represenation_number,
+molecule_class_info_t::adjust_additional_representation(int representation_number,
                                                         const int &bonds_box_type_in,
                                                         float bonds_width,
                                                         bool draw_hydrogens_flag,


### PR DESCRIPTION
hi there

this PR fixes a trivial typo represenation/representation in a number of sources, which was causing compile failures like:

```
    molecules-container.cc:5481:1: error: no declaration matches 'void molecules_container_t::export_molecular_represenation_as_gltf(int, const std::string&, const std::string&, const std::string&, int, const std::string&)'
     5481 | molecules_container_t::export_molecular_represenation_as_gltf(int imol, const std::string &atom_selection_cid,
          | ^~~~~~~~~~~~~~~~~~~~~
    molecules-container.cc:5481:1: note: no functions named 'void molecules_container_t::export_molecular_represenation_as_gltf(int, const std::string&, const std::string&, const std::string&, int, const std::string&)'
    In file included from molecules-container.cc:32:
    molecules-container.hh:41:7: note: 'class molecules_container_t' defined here
       41 | class molecules_container_t {
          |       ^~~~~~~~~~~~~~~~~~~~~
    make[2]: *** [Makefile:801: molecules-container.lo] Error 1

```