### PR TITLE
Update coot.desktop

### DIFF
--- a/coot.desktop
+++ b/coot.desktop
@@ -2,9 +2,10 @@
 Type=Application
 Name=Coot
 GenericName=Crystallographic Object-Oriented Toolkit
-Comment=Macromolecular model builder
+Comment=Crystallographic Object-Oriented Toolkit
 Exec=coot %f
 Icon=io.github.pemsley.coot
+StartupWMClass=coot-1
 Terminal=false
 Categories=Science;Chemistry;Biology;GTK;
 MimeType=chemical/x-pdb;chemical/x-mmcif;chemical/x-mdl-molfile;


### PR DESCRIPTION
- Added `StartupWMClass` in coot.desktop in order not to spawn cloned icons upon launching flatpak  Coot
- Updated `Comment` in coot.desktop, which is used on Flathub