### PR TITLE
Update Makefile.am - added libcoot-protein-db to libcoot_map_utils

### DIFF
--- a/coot-utils/Makefile.am
+++ b/coot-utils/Makefile.am
@@ -142,6 +142,7 @@ libcoot_map_utils_la_SOURCES = coot-map-utils.cc peak-search.cc peak-search-from
 libcoot_map_utils_la_LIBADD = \
    libcoot-coord-utils.la \
    $(top_builddir)/lidia-core/libcoot-lidia-core.la \
+   $(top_builddir)/protein_db/libcoot-protein-db.la \
    $(top_builddir)/geometry/libcoot-geometry.la \
    $(top_builddir)/utils/libcoot-utils.la \
    $(CLIPPER_LIBS) $(gsl_LIBS) -lpthread -lz


### PR DESCRIPTION
Otherwise I'm getting

/usr/bin/ld: ./.libs/libcoot-map-utils.so: undefined reference to `ProteinDB::ProteinDBSearch::search(ProteinDB::Chain const&, int, clipper::Xmap<float> const&, std::vector<clipper::Coord_orth, std::allocator<clipper::Coord_orth> > const&, double, double, double, double, double)'