### PR TITLE
Fix use of undefined scale_up_graphics and scale_down_graphics

### DIFF
--- a/src/graphics-info-draw.cc
+++ b/src/graphics-info-draw.cc
@@ -60,6 +60,8 @@
 
 enum {VIEW_CENTRAL_CUBE, ORIGIN_CUBE};
 
+int graphics_info_t::scale_up_graphics = 1;
+int graphics_info_t::scale_down_graphics = 1;
 
 glm::vec3
 get_camera_up_direction(const glm::mat4 &mouse_quat_mat) {
@@ -632,6 +634,7 @@ graphics_info_t::get_light_space_mvp(int light_index) {
 glm::mat4
 graphics_info_t::get_molecule_mvp(bool debug_matrices) {
 
+   graphics_info_t g;
    int w = graphics_x_size;
    int h = graphics_y_size;
 
@@ -642,13 +645,13 @@ graphics_info_t::get_molecule_mvp(bool debug_matrices) {
       h = allocation.height;
    }
 
-   if (scale_up_graphics != 1) {
-      w *= scale_up_graphics;
-      h *= scale_up_graphics;
+   if (g.scale_up_graphics != 1) {
+      w *= g.scale_up_graphics;
+      h *= g.scale_up_graphics;
    }
-   if (scale_down_graphics != 1) {
-      w /= scale_down_graphics;
-      h /= scale_down_graphics;
+   if (g.scale_down_graphics != 1) {
+      w /= g.scale_down_graphics;
+      h /= g.scale_down_graphics;
    }
    // std::cout << scale_up_graphics << " " << scale_down_graphics << " " << w << " " << h << std::endl;
 

--- a/src/graphics-info-render-scene.cc
+++ b/src/graphics-info-render-scene.cc
@@ -729,6 +729,7 @@ graphics_info_t::render_scene() {
       // std::cout << "--- render_scene_basic() ---------------------------------------- " << std::endl;
       // auto tp_0 = std::chrono::high_resolution_clock::now();
 
+      graphics_info_t g;// needed? Yes.
       GtkAllocation allocation;
       auto gl_area = graphics_info_t::glareas[0];
       gtk_widget_get_allocation(gl_area, &allocation);
@@ -744,13 +745,13 @@ graphics_info_t::render_scene() {
       // we always want this viewport to be the size of the widget (in the case of APPLE, theree
       // is the double resolution issue to handle)
 
-      if (scale_up_graphics != 1) {
-         width *= scale_up_graphics;
-         height *= scale_up_graphics;
+      if (g.scale_up_graphics != 1) {
+         width *= g.scale_up_graphics;
+         height *= g.scale_up_graphics;
       }
-      if (scale_down_graphics != 1) {
-         width /= scale_down_graphics;
-         height /= scale_down_graphics;
+      if (g.scale_down_graphics != 1) {
+         width /= g.scale_down_graphics;
+         height /= g.scale_down_graphics;
       }
       // std::cout << "render_scene_basic() " << width << " " << height << std::endl;
 
@@ -768,7 +769,6 @@ graphics_info_t::render_scene() {
          tmesh_for_background_image.draw(&shader_for_background_image, HUDTextureMesh::TOP_LEFT);
       }
       
-      graphics_info_t g;// needed? Yes.
       g.draw_models(&shader_for_tmeshes, &shader_for_meshes, nullptr, nullptr, width, height);
       draw_rotation_centre_crosshairs(GTK_GL_AREA(gl_area), PASS_TYPE_STANDARD);
       render_3d_scene(GTK_GL_AREA(gl_area));


### PR DESCRIPTION
hi

since 40fa36650795b19286c3c535d7d4e30a72a4046f building from source was failing with:

```
    /usr/bin/ld: ./.libs/libcootsumo.so: undefined reference to `graphics_info_t::scale_up_graphics'
    /usr/bin/ld: ./.libs/libcootsumo.so: undefined reference to `graphics_info_t::scale_down_graphics'
    collect2: error: ld returned 1 exit status
    make[3]: *** [Makefile:1980: coot-density-score-by-residue-bin] Error 1
```

Turned out that in ``graphics-info-draw.cc`` and ``graphics-info-render-scene.cc`` both ``scale_up_graphics`` and ``scale_down_graphics`` were being used, but were actually undefined.

This pull request fixes that.

ciao
gabriele
