### PR TITLE
Fix use of undefined scale_up_graphics and scale_down_graphics

### DIFF
--- a/src/graphics-info-draw.cc
+++ b/src/graphics-info-draw.cc
@@ -61,6 +61,8 @@
 
 enum {VIEW_CENTRAL_CUBE, ORIGIN_CUBE};
 
+int graphics_info_t::scale_up_graphics = 1;
+int graphics_info_t::scale_down_graphics = 1;
 
 glm::vec3
 get_camera_up_direction(const glm::mat4 &mouse_quat_mat) {
@@ -633,6 +635,7 @@ graphics_info_t::get_light_space_mvp(int light_index) {
 glm::mat4
 graphics_info_t::get_molecule_mvp(bool debug_matrices) {
 
+   graphics_info_t g;
    int w = graphics_x_size;
    int h = graphics_y_size;
 
@@ -643,13 +646,13 @@ graphics_info_t::get_molecule_mvp(bool debug_matrices) {
       h = allocation.height;
    }
 
-   if (scale_up_graphics != 1) {
-      w *= scale_up_graphics;
-      h *= scale_up_graphics;
+   if (g.scale_up_graphics != 1) {
+      w *= g.scale_up_graphics;
+      h *= g.scale_up_graphics;
    }
-   if (scale_down_graphics != 1) {
-      w /= scale_down_graphics;
-      h /= scale_down_graphics;
+   if (g.scale_down_graphics != 1) {
+      w /= g.scale_down_graphics;
+      h /= g.scale_down_graphics;
    }
    // std::cout << scale_up_graphics << " " << scale_down_graphics << " " << w << " " << h << std::endl;
 

--- a/src/graphics-info-render-scene.cc
+++ b/src/graphics-info-render-scene.cc
@@ -733,6 +733,7 @@ graphics_info_t::render_scene() {
       if (err)
          std::cout << "GL ERROR:: render_scene_basic() --- start --- " << err << std::endl;
 
+      graphics_info_t g;// needed? Yes.
       GtkAllocation allocation;
       auto gl_area = graphics_info_t::glareas[0];
       gtk_widget_get_allocation(gl_area, &allocation);
@@ -748,13 +749,13 @@ graphics_info_t::render_scene() {
       // we always want this viewport to be the size of the widget (in the case of APPLE, theree
       // is the double resolution issue to handle)
 
-      if (scale_up_graphics != 1) {
-         width *= scale_up_graphics;
-         height *= scale_up_graphics;
+      if (g.scale_up_graphics != 1) {
+         width *= g.scale_up_graphics;
+         height *= g.scale_up_graphics;
       }
-      if (scale_down_graphics != 1) {
-         width /= scale_down_graphics;
-         height /= scale_down_graphics;
+      if (g.scale_down_graphics != 1) {
+         width /= g.scale_down_graphics;
+         height /= g.scale_down_graphics;
       }
       // std::cout << "render_scene_basic() " << width << " " << height << std::endl;
 
@@ -800,7 +801,6 @@ graphics_info_t::render_scene() {
          tmesh_for_background_image.draw(&shader_for_background_image, HUDTextureMesh::TOP_LEFT);
       }
       
-      graphics_info_t g;// needed? Yes.
       err = glGetError();
       if (err)
          std::cout << "GL ERROR:: render_scene_basic() H " << err << std::endl;


### PR DESCRIPTION
hi

this is an updated version of pull request https://github.com/pemsley/coot/pull/194#issue-2793184058, to catch up with the 
recent commit ``42efdb459f8a8e91c720af515790dd2fb9fb33a2`` to ``graphics-info-render-scene.cc``.

The original pull request https://github.com/pemsley/coot/pull/194#issue-2793184058 had been closed, but I reopened it since the commit supposed to fix the issue was actually incomplete. Here is the link to my comment upon reopening for your convenience: https://github.com/pemsley/coot/pull/194#issuecomment-2614469955

Current master (branch ``main``) still fails for me with the same error:

```
/usr/bin/ld: ./.libs/libcootsumo.so: undefined reference to `graphics_info_t::scale_up_graphics'
/usr/bin/ld: ./.libs/libcootsumo.so: undefined reference to `graphics_info_t::scale_down_graphics'
collect2: error: ld returned 1 exit status
```

This (updated) pull request fixes things for me

Thanks
ciao
-g
 