### PR TITLE
Added installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ coot
 
 ### Flatpak (Linux in general)
 
-<a href="https://flathub.org/apps/io.github.pemsley.coot"><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.svg' align="right"/></a>
+![Flathub version](https://img.shields.io/flathub/v/io.github.pemsley.coot)
+
+<div>
+  <a href="https://flathub.org/apps/io.github.pemsley.coot">
+    <img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.svg' align="right"/>
+  </a>
+</div>
 
 After [installing Flatpak and registering Flathub](https://flatpak.org/setup/), run the commands below.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ refinement and validation.
 
 ## Installation
 
-### Homebrew (Mac / Linux)
+### Homebrew (MacOS / Linux)
 
 After [installing Homebrew](https://brew.sh/), run the commands below.
 
@@ -53,7 +53,7 @@ You can see the flatpak manifest [here](https://github.com/flathub/io.github.pem
 
 Download the installer for WinCoot from [here](https://bernhardcl.github.io/coot/wincoot-download.html).
 
-### As a component of CCP4 Suite
+### As a component of CCP4 Suite (Linux / MacOS / Windows)
 
 Coot-1 can be installed by using the package manager included in the CCP4 suite.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ refinement and validation.
 
 ## Installation
 
-### CCP4
-
 ### Homebrew (Mac / Linux)
 
 After [installing Homebrew](https://brew.sh/), run the commands below.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ model-building.  *Coot* uses GTK widgets
 mmdb, clipper, and OpenGL to provide interactive tools for model-building,
 refinement and validation.
 
-## Installing by package managers
+## Installation
 
-The easiest way to install *Coot* is using package managers.
+### CCP4
 
 ### Homebrew (Mac / Linux)
 
@@ -50,6 +50,16 @@ flatpak run io.github.pemsley.coot
 ```
 
 You can see the flatpak manifest [here](https://github.com/flathub/io.github.pemsley.coot).
+
+### Windows
+
+Download the installer for WinCoot from [here](https://bernhardcl.github.io/coot/wincoot-download.html).
+
+### As a component of CCP4 Suite
+
+Coot-1 can be installed by using the package manager included in the CCP4 suite.
+
+CCP4 Suite is can be downloaded from [CCP4 Download pages](https://www.ccp4.ac.uk/download/).
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ coot
 
 ### Flatpak (Linux in general)
 
-![Flathub version](https://img.shields.io/flathub/v/io.github.pemsley.coot)
+![Flathub version](https://img.shields.io/flathub/v/io.github.pemsley.coot.svg?logo=flatpak&logoColor=white&color=blue&style=flat)
 
 <div>
   <a href="https://flathub.org/apps/io.github.pemsley.coot">


### PR DESCRIPTION
I thought it would be better to include how to install Coot-1 on Windows and CCP4, so I modified README.md