### PR TITLE
Attempt at better check for EM map

### DIFF
--- a/coot-utils/slurp-map.cc
+++ b/coot-utils/slurp-map.cc
@@ -264,9 +264,8 @@ coot::util::slurp_parse_xmap_data(char *data,
    if (check_only) {
       if (mx > 0 && my > 0 && mz > 0) {
          if (space_group_number == 1)
-            status = true;
-         if (space_group_number == 0)
-            status = true;
+            if(fabs(cell_al-90)<1e-4&&fabs(cell_be-90)<1e-4&&fabs(cell_ga-90)<1e-4)
+               status = true;
       }
       return status;
    }


### PR DESCRIPTION
Hope this is a better way of deciding if we have an em map.
Remove what I believe to be redundant check if(space_group_number == 0) as it is set to 1 earlier.