### PR TITLE
Add release notes for version 1.1.17 to `coot.appdata.xml`

### DIFF
--- a/coot.appdata.xml
+++ b/coot.appdata.xml
@@ -52,6 +52,16 @@
   <update_contact>pemsley_AT_mrc-lmb.cam.ac.uk</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.1.17" date="2025-06-14">
+      <description>
+        <ul>
+          <li> o BUG-FIX: Save symmetry coordinates is fixed </li>
+          <li> o BUG-FIX: Colour-by-B-factor colours are fixed </li>
+          <li> o BUG-FIX: Place atom at pointer fixed </li>
+          <li> o BUG-FIX: Optional Gemmi usage restored </li>
+        </ul>
+      </description>
+    </release>
     <release version="1.1.16" date="2025-06-04">
       <description>
         <ul>


### PR DESCRIPTION
This is necessary for Flathub to reflect that the version has been upgraded.

---

This pull request updates the `coot.appdata.xml` file to include details about a new software release. The most notable change is the addition of version `1.1.17` with its release date and a list of bug fixes.

Release updates:

* Added a new release entry for version `1.1.17` with the release date `2025-06-14`. The update includes descriptions of four bug fixes:
  - Fixed saving symmetry coordinates.
  - Fixed color-by-B-factor coloring.
  - Fixed placing atoms at the pointer.
  - Restored optional Gemmi usage.