### PR TITLE
Replace `Python 3.12.4` with `Python 3` in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,7 @@ find_package(glm REQUIRED)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
-# Charles wants 3.9 here, but if I change to 3.9 then it will not build for me
-# Hmm...
-# What do I need to do here so that Charles can specify on the command line what the version of Python should be?
-find_package(Python 3.12.4
+find_package(Python 3
   REQUIRED COMPONENTS Interpreter Development.Module
   OPTIONAL_COMPONENTS Development.SABIModule)
 


### PR DESCRIPTION
What do you think about modifying it to support a wide range of Python3 versions?

---

This pull request updates the `CMakeLists.txt` file to simplify the specification of the Python version in the `find_package` command. The change removes hardcoded version constraints, allowing greater flexibility for specifying the Python version.

Key change:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL32-R32): Updated `find_package(Python)` to remove the hardcoded Python version `3.12.4`, enabling users to specify the desired Python version via the command line.