### PR TITLE
Include `filesystem` header in molecules-container-nanobind

### DIFF
--- a/api/molecules-container-nanobind.cc
+++ b/api/molecules-container-nanobind.cc
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <unordered_map>
 #include <sstream>
 


### PR DESCRIPTION
This pull request makes a minor update to the `api/molecules-container-nanobind.cc` file by adding an include for the `<filesystem>` header. This likely prepares the code for future use of filesystem-related functionality or resolves a missing dependency.