### PR TITLE
Fix variable assignment in `AC_ARG_WITH` for sound

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -482,7 +482,7 @@ fi
 AM_COOT_SYS_BUILD_TYPE
 
 
-AC_ARG_WITH([sound], AS_HELP_STRING([--with-sound compile with ogg-vorbis and OpenAL libs]), with_sound="withval", with_sound=false)
+AC_ARG_WITH([sound], AS_HELP_STRING([--with-sound compile with ogg-vorbis and OpenAL libs]), with_sound="$withval", with_sound=false)
 AC_MSG_CHECKING([for sound])
 if test "x$with_sound" = xfalse ; then
    :


### PR DESCRIPTION
This pull request makes a minor fix to the `configure.ac` script, correcting the way the `with_sound` variable is set when the `--with-sound` argument is provided.

- Build configuration:
  * Fixed the assignment of the `with_sound` variable in the `AC_ARG_WITH([sound], ...)` macro to correctly use the value provided by the user (`$withval`) instead of the string `"withval"`.