### PR TITLE
Add fcntl.h include for file control operations

### DIFF
--- a/src/json-rpc.cc
+++ b/src/json-rpc.cc
@@ -8,6 +8,7 @@
 
 #include <gtk/gtk.h>
 #include <netinet/in.h>
+#include <fcntl.h>
 #include <coot-utils/json.hpp>
 
 #include <utils/coot-utils.hh>


### PR DESCRIPTION
Missing include - for GCC 11 (Ubuntu 22.04 - EOL = June 2027) and GCC 13 (Ubuntu 24.04)