### PR TITLE
Fix TER atom counting in amber trajectory processing

### DIFF
--- a/coot-utils/read-amber-trajectory.cc
+++ b/coot-utils/read-amber-trajectory.cc
@@ -125,7 +125,12 @@ namespace coot {
                   for (int ir = 0; ir < n_res; ir++) {
                      mmdb::Residue *res = chain->GetResidue(ir);
                      if (res) {
-                        n_atoms_topology += res->GetNumberOfAtoms();
+                        int n_at = res->GetNumberOfAtoms();
+                        for (int ia = 0; ia < n_at; ia++) {
+                           mmdb::Atom *at = res->GetAtom(ia);
+                           if (at && !at->Ter)
+                              n_atoms_topology++;
+                        }
                      }
                   }
                }
@@ -238,6 +243,7 @@ namespace coot {
                for (int ia = 0; ia < n_at; ia++) {
                   mmdb::Atom *template_atom = template_res->GetAtom(ia);
                   if (!template_atom) continue;
+                  if (template_atom->Ter) continue; // skip TER pseudo-atoms
 
                   mmdb::Atom *new_atom = new mmdb::Atom();
                   new_atom->Copy(template_atom);


### PR DESCRIPTION
This pull request updates the logic for handling atoms in the Amber trajectory reader, specifically to exclude "TER" pseudo-atoms from atom counting and copying operations. This ensures that only real atoms are processed, improving accuracy and consistency in the code.

Atom handling improvements:

* Updated the atom counting logic to skip atoms marked as `Ter` (pseudo-atoms) when tallying the number of atoms in a residue, ensuring only real atoms are counted.
* Modified the atom copying logic to skip `Ter` pseudo-atoms when creating new atom objects from template atoms, preventing unnecessary or incorrect copying of pseudo-atoms.