### PR TITLE
Add Altona-Sundaralingam ribose pucker calculation

### DIFF
--- a/api/coot-molecule.cc
+++ b/api/coot-molecule.cc
@@ -48,8 +48,6 @@
 #include "add-terminal-residue.hh"
 #include "molecules-container.hh"
 
-#include <gemmi/mmread.hpp>
-#include <gemmi/pdb.hpp>
 
 bool
 coot::molecule_t::is_valid_model_molecule() const {

--- a/api/coot-molecule.cc
+++ b/api/coot-molecule.cc
@@ -48,6 +48,9 @@
 #include "add-terminal-residue.hh"
 #include "molecules-container.hh"
 
+#include <gemmi/mmread.hpp>
+#include <gemmi/pdb.hpp>
+
 bool
 coot::molecule_t::is_valid_model_molecule() const {
 
@@ -5377,7 +5380,7 @@ using json = nlohmann::json;
 std::string
 coot::molecule_t::get_pucker_analysis_info() const {
 
-   std::string s;
+      std::string s;
 
    std::vector<std::pair<mmdb::Residue *, pucker_analysis_info_t> > puckers;
    std::string alt_conf = "";
@@ -5454,6 +5457,8 @@ coot::molecule_t::get_pucker_analysis_info() const {
          j_pucker["phosphorus_position"]          = j_markup_info_base_phosphorus_position;
          j_pucker["projected_point"]             = j_markup_info_base_projected_point;
          j_pucker["phosphate_distance_to_base_plane"] = j_markup_info_phosphorus_distance_to_base_plane;
+         j_pucker["P_deg"] = pi.P_deg;
+         j_pucker["pucker_name"] = pi.pucker_name;
          j.push_back(j_pucker);
       }
       s = j.dump(4);

--- a/coot-utils/coot-coord-utils-nucleotides.cc
+++ b/coot-utils/coot-coord-utils-nucleotides.cc
@@ -112,6 +112,10 @@ coot::pucker_analysis_info_t::pucker_analysis_info_t(mmdb::Residue *res_p,
                                   ribose_atoms[i_oop_atom]->z);
             ribose_atoms_coords.push_back(c);
          }
+
+         P_deg = compute_pucker_parameter(ribose_atoms_coords);
+         pucker_name = classify_pucker(P_deg);
+
          // oop: out of plane distance
          std::vector<std::pair<float, float> > pucker_distortion_and_oop_d(5);
          for (int i_oop_atom=0; i_oop_atom<5; i_oop_atom++) {
@@ -174,15 +178,14 @@ coot::pucker_analysis_info_t::to_json() const {
    j["plane_distortion"]      = j_plane_distortion;
    j["out_of_plane_distance"] = j_out_of_plane_distance;
    j["puckered_atom"]         = j_puckered_atom;
-
+   j["P_deg"] = P_deg;
+   j["pucker_name"] = pucker_name;
    // json["plane_distortion"] = plane_distortion;
    // json["out_of_plane_distance"] = out_of_plane_distance;
    // json["puckered_atom"] = puckered_atom();
    std::string s = j.dump(4);
    return s;
 }
-
-
 
 void
 coot::pucker_analysis_info_t::assign_base_atom_coords(mmdb::Residue *residue_p) {
@@ -302,8 +305,60 @@ coot::pucker_analysis_info_t::assign_base_atom_coords(mmdb::Residue *residue_p) 
          }
       }
    }
-} 
+}
 
+double coot::pucker_analysis_info_t::compute_pucker_parameter(std::vector<clipper::Coord_orth> &coordinates) {
+      clipper::Coord_orth c1_prime = coordinates[0];
+   clipper::Coord_orth c2_prime = coordinates[1];
+   clipper::Coord_orth c3_prime = coordinates[2];
+   clipper::Coord_orth c4_prime = coordinates[3];
+   clipper::Coord_orth o4_prime = coordinates[4];
+
+   double v_0 = clipper::Coord_orth::torsion(c4_prime, o4_prime, c1_prime, c2_prime);
+   double v_1 = clipper::Coord_orth::torsion(o4_prime, c1_prime, c2_prime, c3_prime);
+   double v_2 = clipper::Coord_orth::torsion(c1_prime, c2_prime, c3_prime, c4_prime);
+   double v_3 = clipper::Coord_orth::torsion(c2_prime, c3_prime, c4_prime, o4_prime);
+   double v_4 = clipper::Coord_orth::torsion(c3_prime, c4_prime, o4_prime, c1_prime);
+
+   constexpr double deg36_r = 36.0 * M_PI / 180.0;
+   constexpr double deg72_r = 72.0 * M_PI / 180.0;
+
+   double numerator = (v_4 + v_1) - (v_3 + v_0);
+   double denominator = 2.0 * v_2 * (std::sin(deg36_r) + std::sin(deg72_r));
+
+   double P_rad = std::atan2(numerator, denominator);
+   double P_deg = P_rad * 180.0 / M_PI;
+
+   // double taum = v_2 / std::cos(P_rad);
+
+   if (P_deg < 0)
+      P_deg += 360.0;
+   return P_deg;
+}
+std::string coot::pucker_analysis_info_t::classify_pucker(double P_deg) {
+   // https://pubs.acs.org/doi/10.1021/ja412079b Figure 1
+   const std::array<std::string, 10> puckers = {
+      "C3-endo",
+      "C4-exo",
+      "O4-endo",
+      "C1-exo",
+      "C2-endo",
+      "C3-exo",
+      "C4-endo",
+      "O4-exo",
+      "C1-endo",
+      "C2-exo"
+  };
+
+   P_deg = std::fmod(P_deg, 360.0);
+   if (P_deg < 0.0)
+      P_deg += 360.0;
+
+   // Canonical envelope pucker centres lie at P = 18° + 36°·k (Altona–Sundaralingam),
+   // so the nearest classification is given by floor(P_deg / 36) mod 10.
+   const auto index = static_cast<std::size_t>(std::floor(P_deg / 36.0)) % puckers.size();
+   return puckers[index];
+}
 
 // Use the 3' phosphate of the following residue to calculate its out
 // of plane distance (the plane being the base plane).  Decide from

--- a/coot-utils/coot-coord-utils.hh
+++ b/coot-utils/coot-coord-utils.hh
@@ -54,6 +54,13 @@
 
 #include "cis-peptide-info.hh"
 
+#include <gemmi/model.hpp>
+#include <gemmi/calculate.hpp>
+
+#include "coot-utils/json.hpp"
+using json = nlohmann::json;
+
+
 namespace coot {
 
    // a generally useful class to be used with std::map where the
@@ -493,6 +500,10 @@ namespace coot {
       void assign_base_atom_coords(mmdb::Residue *residue_p);
       mmdb::Atom *N1_or_9;
       mmdb::Atom *C1_prime;
+
+      static double compute_pucker_parameter(std::vector<clipper::Coord_orth>& coordinates);
+      static std::string classify_pucker(double P_deg);
+
    public:
       float plane_distortion;
       float out_of_plane_distance;
@@ -500,6 +511,8 @@ namespace coot {
       std::vector<clipper::Coord_orth> base_atoms_coords; // the perpendicular distance of the
                                                           // following phosphate is to the *BASE*
                                                           // atoms (stupid boy).
+      double P_deg;
+      std::string pucker_name;
 
       // Throw an exception if it is not possible to generate pucker info
       //
@@ -515,7 +528,6 @@ namespace coot {
       std::string puckered_atom() const;
       std::string to_json() const;
    };
-
 
 
    class graph_match_info_t {

--- a/coot-utils/coot-coord-utils.hh
+++ b/coot-utils/coot-coord-utils.hh
@@ -54,11 +54,6 @@
 
 #include "cis-peptide-info.hh"
 
-#include <gemmi/model.hpp>
-#include <gemmi/calculate.hpp>
-
-#include "coot-utils/json.hpp"
-using json = nlohmann::json;
 
 
 namespace coot {


### PR DESCRIPTION
This PR Adds the Altona-Sundaralingam ribose pucker calculation to the get_pucker_analysis_info function. 

New fields in JSON
- P_deg - the pseudorotation angle
- pucker_name - the name of the conformation (e.g. C2-exo, C3-endo)