### PR TITLE
Fix stdint bug in Cremer-Pople Sphere

### DIFF
--- a/cremer-pople-sphere/density_map.cc
+++ b/cremer-pople-sphere/density_map.cc
@@ -3,6 +3,7 @@
 //
 
 #include "density_map.hh"
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
This PR adds the stdint header to Cremer-Pople for Ubuntu building