### PR TITLE
Fix compilation issue on macOS Sonoma

### DIFF
--- a/src/cc-interface-map-utils.cc
+++ b/src/cc-interface-map-utils.cc
@@ -881,7 +881,7 @@ void emplacement_by_phaser(const std::string &half_map_1_file_name, const std::s
       std::cout << "WARNING:: " << em_placement_output_file_name << " exists and can't be moved"<< std::endl;
    } else {
       if (is_valid_model_molecule(imol_model)) {
-         em_placement_data_t *data_p = new em_placement_data_t(em_placement_output_file_name, 0);
+         em_placement_data_t *data_p = new em_placement_data_t{em_placement_output_file_name};
          std::string model_file_name = "input-model-for-emplacement.pdb";
          write_pdb_file(imol_model, model_file_name.c_str());
          std::thread thread(run_subprocess, half_map_1_file_name, half_map_2_file_name, model_file_name, search_centre);


### PR DESCRIPTION
Dear @pemsley,

Congratulations on the 1.3.2 release. I have already updated the Homebrew version to match it.

While doing so, I encountered a compilation error during this build only on macos-14.
The error is shown below:

```
  libtool: compile:  clang++ -DPACKAGE_NAME=\"coot\" -DPACKAGE_TARNAME=\"coot\" -DPACKAGE_VERSION=\"1.3.2\" "-DPACKAGE_STRING=\"coot 1.3.2\"" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"coot\" -DVERSION=\"1.3.2\" -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_CXX11=1 -DHAVE_CXX_THREAD=1 -DHAVE_LIBM=1 -DHAVE_LIBGSLCBLAS=1 -DHAVE_LIBGSL=1 -DHAVE_PYTHON=\"3.14\" "-DHAVE_BOOST=/**/" "-DHAVE_BOOST_THREAD=/**/" "-DHAVE_BOOST_PYTHON=/**/" -DHAVE_RSVG=1 -DHAVE_NETCDF=1 -I. -DUSE_PYTHON -I/opt/homebrew/Cellar/gtk4/4.22.4/include/gtk-4.0 -I/opt/homebrew/Cellar/pango/1.58.2/include/pango-1.0 ... -I/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/ffi -I/opt/homebrew/opt/python@3.14/Frameworks/Python.framework/Versions/3.14/include/python3.14 -g -O2 -Wall -Wno-unused -std=c++20 -MT cc-interface-subprocess.lo -MD -MP -MF .deps/cc-interface-subprocess.Tpo -c cc-interface-subprocess.cc -o cc-interface-subprocess.o >/dev/null 2>&1
  cc-interface-map-utils.cc:884:44: error: no matching constructor for initialization of 'em_placement_data_t'
           em_placement_data_t *data_p = new em_placement_data_t(em_placement_output_file_name, 0);
                                             ^                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cc-interface-map-utils.cc:812:11: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
     struct em_placement_data_t {
            ^
  cc-interface-map-utils.cc:812:11: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
  cc-interface-map-utils.cc:812:11: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided
  1 error generated.
  make[1]: *** [cc-interface-map-utils.lo] Error 1
  make[1]: *** Waiting for unfinished jobs....
```

To address this error, I applied the following patch:
https://github.com/brewsci/homebrew-bio/pull/2338/changes/74e5b8a97c4940f3b8025721f2a0b2f3230b8b59

Accordingly, I have created this PR and would appreciate your consideration for merging it.