### PR TITLE
Add 'make a smoother copy of map' command and update documentation

### DIFF
--- a/api/molecules-container.cc
+++ b/api/molecules-container.cc
@@ -3368,6 +3368,8 @@ molecules_container_t::sharpen_blur_map(int imol_map, float b_factor, bool in_pl
          bool is_em = molecules[imol_map].is_EM_map();
          coot::molecule_t cm(name, imol_new, is_em);
          cm.xmap = xmap_new;
+         // a sharpened/blurred difference map is still a difference map
+         cm.set_map_is_difference_map(molecules[imol_map].is_difference_map_p());
          molecules.push_back(cm);
       }
    }
@@ -3397,8 +3399,11 @@ molecules_container_t::sharpen_blur_map_with_resample(int imol_map, float b_fact
             name += coot::util::float_to_string_using_dec_pl(resample_factor, 2);
          }
          imol_new = molecules.size();
-         coot::molecule_t cm(name, imol_new);
+         bool is_em = molecules[imol_map].is_EM_map();
+         coot::molecule_t cm(name, imol_new, is_em);
          cm.xmap = xmap_new;
+         // a sharpened/blurred/resampled difference map is still a difference map
+         cm.set_map_is_difference_map(molecules[imol_map].is_difference_map_p());
          molecules.push_back(cm);
       }
    }

--- a/doc/command-reference.md
+++ b/doc/command-reference.md
@@ -39,7 +39,7 @@ follows for free.
 - [Help](#help) - 1 command
 - [Labels](#labels) - 1 command
 - [Ligand](#ligand) - 1 command
-- [Maps](#maps) - 4 commands
+- [Maps](#maps) - 5 commands
 - [Model editing](#model-editing) - 10 commands
 - [Models](#models) - 2 commands
 - [Navigation](#navigation) - 4 commands
@@ -333,6 +333,18 @@ Examples:
 
 Marks the map as a difference map (green/red, contoured either side of zero). With no map number, acts on the active map.
 
+### `make a smoother copy of map 1`
+
+Make a smoother (finer-sampled) copy of a map.
+
+Examples:
+
+- `make a smoother copy of map 1`
+- `smooth map 1 by 2`
+- `smooth map`
+
+Interpolates the map onto a finer grid, making a new map molecule and leaving the original alone. The factor multiplies the existing grid sampling (the default is 1.25, as in Calculate -> Map Tools); larger factors are smoother and use more memory. Unlike 'set map sampling rate' this acts on a map that is already loaded, but it interpolates the existing grid rather than re-transforming the structure factors, so it adds no real detail. With no map number, acts on the active map.
+
 
 ## Model editing
 
@@ -357,7 +369,7 @@ Examples:
 - `add solvent SO4 here`
 - `add ligand GOL`
 
-Fetches the named monomer from the dictionary and moves it to the screen centre. 
+Fetches the named monomer from the dictionary and moves it to the screen centre. Use "add water" for a single water atom, and "fit ligand" to search for it in the density instead.
 
 ### `add OXT to A/89`
 
@@ -869,7 +881,7 @@ Examples:
 - `set map sampling rate to 1.8`
 - `set map sampling 2`
 
-Finer sampling (higher rate) makes smoother maps at the cost of memory. Applies to maps read after it is set; typical values are 1.5-2.5.
+Finer sampling (higher rate) makes smoother maps at the cost of memory; typical values are 1.5-2.5. The rate is only read when a map is created from structure factors, so this has no effect on maps already loaded - to smooth one of those, use 'make a smoother copy of map N'.
 
 ### `set updating maps on`
 

--- a/python/coot_commands/commands/maps.py
+++ b/python/coot_commands/commands/maps.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 from typing import Optional
 
 from coot_commands.registry import command
-from coot_commands.types import (resolve_map, resolve_colour, as_float, ArgType,
-                                 ACTIVE_MAP_NOTE)
+from coot_commands.types import (resolve_map, require_map, resolve_colour,
+                                 as_float, ArgType, ACTIVE_MAP_NOTE,
+                                 CommandError)
 
 try:
     import coot
@@ -61,6 +62,35 @@ def contour_absolute(level: str, map: Optional[str] = None) -> str:
     if coot is not None:
         coot.set_contour_level_absolute(imol, lvl)
     return f"Contoured map {imol} at {lvl:g}"
+
+
+@command(r"(?:(?:make )?(?:a )?smoother copy(?: of)?|smooth(?:en)?)"
+         r"(?: map)?(?: (?P<map>(?!by\b|x\b)\S+))?"
+         r"(?:(?: by| x) (?P<factor>[\d.]+))?$",
+         examples=["make a smoother copy of map 1", "smooth map 1 by 2",
+                   "smooth map"],
+         category=CATEGORY,
+         arg_types={"map": ArgType.MAP},
+         notes="Interpolates the map onto a finer grid, making a new map "
+               "molecule and leaving the original alone. The factor "
+               "multiplies the existing grid sampling (the default is 1.25, "
+               "as in Calculate -> Map Tools); larger factors are smoother "
+               "and use more memory. Unlike 'set map sampling rate' this "
+               "acts on a map that is already loaded, but it interpolates "
+               "the existing grid rather than re-transforming the structure "
+               "factors, so it adds no real detail. " + ACTIVE_MAP_NOTE)
+def smooth_map(map: Optional[str] = None, factor: Optional[str] = None) -> str:
+    """Make a smoother (finer-sampled) copy of a map."""
+    imol = require_map(resolve_map(map))
+    mult = 1.25 if factor is None else as_float(factor, "smoothing factor")
+    if mult <= 1.0:
+        raise CommandError(f"the smoothing factor must be more than 1, got {mult:g}")
+    if coot is None:
+        return f"Would smooth map {imol} by a factor of {mult:g}"
+    imol_new = coot.smooth_map(imol, mult)
+    if imol_new < 0:
+        raise CommandError(f"could not make a smoother copy of map {imol}")
+    return f"Made map {imol_new}: map {imol} smoothed by a factor of {mult:g}"
 
 
 @command(r"colou?r map(?: (?P<map>\S+))? (?P<colour>\S+)",

--- a/python/coot_commands/commands/settings.py
+++ b/python/coot_commands/commands/settings.py
@@ -167,14 +167,18 @@ def get_map_radius(**_: Optional[str]) -> str:
          examples=["set map sampling rate to 1.8", "set map sampling 2"],
          category=CATEGORY,
          notes="Finer sampling (higher rate) makes smoother maps at the cost "
-               "of memory. Applies to maps read after it is set; typical "
-               "values are 1.5-2.5.")
+               "of memory; typical values are 1.5-2.5. The rate is only read "
+               "when a map is created from structure factors, so this has no "
+               "effect on maps already loaded - to smooth one of those, use "
+               "'make a smoother copy of map N'.")
 def set_map_sampling_rate(value: str) -> str:
     """Set the map sampling rate for maps read from now on."""
     rate = as_float(value, "map sampling rate")
     if coot is not None:
         coot.set_map_sampling_rate(rate)
-    return f"Set map sampling rate to {rate:g}"
+    return (f"Set map sampling rate to {rate:g} - this applies to maps read "
+            "from now on; for a map that is already loaded, try "
+            "'make a smoother copy of map N'")
 
 
 @command(_GET + r"map sampling(?: rate)?\??",

--- a/python/test_coot_commands.py
+++ b/python/test_coot_commands.py
@@ -35,6 +35,7 @@ import coot_commands  # noqa: F401  - triggers command discovery/registration
 from coot_commands import types
 from coot_commands.commands import files as files_mod
 from coot_commands.commands import ligand as ligand_mod
+from coot_commands.commands import maps as maps_mod
 from coot_commands.commands import model_edit as model_edit_mod
 from coot_commands.commands import models as models_mod
 from coot_commands.commands import refine as refine_mod
@@ -654,6 +655,47 @@ def test_contour_level_on_a_model_is_rejected():
         out = cli.run_command("set contour level of map 0 to 0.3")
         assert "is a model, not a map" in out
         assert 0 not in fake.absolute
+
+
+def test_smooth_map_makes_a_new_map():
+    fake = _FakeCootFull()
+    calls = {}
+
+    def fake_smooth(imol, factor):
+        calls["args"] = (imol, factor)
+        return 7  # the new map's molecule number
+
+    fake.smooth_map = fake_smooth
+    with _use_coot(fake, maps_mod):
+        # No map named and no factor -> the active map at the GUI's default
+        # factor, and the reply names the *new* map so it can be worked on.
+        out = cli.run_command("smooth map")
+        assert calls["args"] == (3, 1.25)
+        assert "Made map 7" in out and "map 3 smoothed by a factor of 1.25" in out
+        # Explicit map and factor, in either phrasing.
+        assert "Made map 7" in cli.run_command("make a smoother copy of map 3 by 2")
+        assert calls["args"] == (3, 2.0)
+        assert "Made map 7" in cli.run_command("smooth map 3 x 1.5")
+        assert calls["args"] == (3, 1.5)
+
+
+def test_smooth_map_rejects_a_model_and_a_useless_factor():
+    fake = _FakeCootFull()
+    fake.smooth_map = lambda imol, factor: 7
+    with _use_coot(fake, maps_mod):
+        # Molecule 0 is a model, not a map.
+        assert "is a model, not a map" in cli.run_command("smooth map 0")
+        # A factor of 1 or less would copy (or coarsen) rather than smooth.
+        assert "must be more than 1" in cli.run_command("smooth map 3 by 1")
+        assert "must be more than 1" in cli.run_command("smooth map 3 by 0.5")
+
+
+def test_smooth_map_reports_a_failed_smooth():
+    fake = _FakeCootFull()
+    fake.smooth_map = lambda imol, factor: -1  # coot's failure return
+    with _use_coot(fake, maps_mod):
+        assert "could not make a smoother copy of map 3" in \
+            cli.run_command("smooth map 3 by 2")
 
 
 def test_get_setting_without_coot():

--- a/src/c-interface-maps.cc
+++ b/src/c-interface-maps.cc
@@ -1841,14 +1841,13 @@ int transform_map_raw(int imol,
                                    rtop, pt, box_size);
 
       const coot::ghost_molecule_display_t ghost_info;
-      // int is_diff_map_flag = graphics_info_t::molecules[imol].is_difference_map_p();
-      // int swap_colours_flag = graphics_info_t::swap_difference_map_colours;
       bool ipz = graphics_info_t::ignore_pseudo_zeros_for_map_stats;
       mean_and_variance<float> mv = map_density_distribution(new_map, 40, false, ipz);
       std::string name = "Transformed map";
       imol_new = graphics_info_t::create_molecule();
       bool is_em_flag = graphics_info_t::molecules[imol].is_EM_map();
-      graphics_info_t::molecules[imol_new].install_new_map(new_map, name, is_em_flag);
+      bool is_diff_map_flag = graphics_info_t::molecules[imol].is_difference_map_p();
+      graphics_info_t::molecules[imol_new].install_new_map(new_map, name, is_em_flag, is_diff_map_flag);
       graphics_draw();
 
    } else {
@@ -1900,7 +1899,8 @@ int reinterp_map(int map_no, int reference_map_no) {
 	 name += " re-interprolated to match ";
 	 name += coot::util::int_to_string(reference_map_no);
 	 bool is_em_flag = graphics_info_t::molecules[map_no].is_EM_map();
-	 graphics_info_t::molecules[imol].install_new_map(new_map, name, is_em_flag);
+	 bool is_diff_map_flag = graphics_info_t::molecules[map_no].is_difference_map_p();
+	 graphics_info_t::molecules[imol].install_new_map(new_map, name, is_em_flag, is_diff_map_flag);
 	 r = imol;
 	 graphics_draw();
       }
@@ -1925,7 +1925,8 @@ int smooth_map(int map_no, float sampling_multiplier) {
       name += " re-interprolated by factor ";
       name += coot::util::float_to_string(sampling_multiplier);
       bool is_em_flag = graphics_info_t::molecules[map_no].is_EM_map();
-      graphics_info_t::molecules[imol].install_new_map(new_map, name, is_em_flag);
+      bool is_diff_map_flag = graphics_info_t::molecules[map_no].is_difference_map_p();
+      graphics_info_t::molecules[imol].install_new_map(new_map, name, is_em_flag, is_diff_map_flag);
       r = imol;
       graphics_draw();
    }
@@ -2775,7 +2776,8 @@ int sharpen_blur_map(int imol_map, float b_factor) {
          map_name += " Blur ";
       map_name += coot::util::float_to_string(b_factor);
       bool is_em_flag = graphics_info_t::molecules[imol_map].is_EM_map();
-      g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_flag);
+      bool is_diff_map_flag = graphics_info_t::molecules[imol_map].is_difference_map_p();
+      g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_flag, is_diff_map_flag);
       float contour_level = graphics_info_t::molecules[imol_map].get_contour_level();
       graphics_info_t::molecules[imol_new].set_contour_level(contour_level);
       float cl = 5.0; // rmsd
@@ -2800,7 +2802,8 @@ int sharpen_blur_map_with_resampling(int imol_map, float b_factor, float resampl
 	 map_name += " Blur ";
       map_name += coot::util::float_to_string(b_factor);
       bool is_em_map_flag = g.molecules[imol_map].is_EM_map();
-      g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag);
+      bool is_diff_map_flag = g.molecules[imol_map].is_difference_map_p();
+      g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag, is_diff_map_flag);
       float contour_level = g.molecules[imol_map].get_contour_level();
       g.molecules[imol_new].set_contour_level(contour_level);
       graphics_draw();
@@ -2830,18 +2833,20 @@ void sharpen_blur_map_with_resampling_threaded_version(int imol_map, float b_fac
          map_name += " Blur ";
       map_name += coot::util::float_to_string(b_factor);
       bool is_em_map_flag = g.molecules[imol_map].is_EM_map();
+      bool is_diff_map_flag = g.molecules[imol_map].is_difference_map_p();
       float contour_level = g.molecules[imol_map].get_contour_level();
       std::promise<clipper::Xmap<float>> computation_result_promise;
 
       struct sbr_callback_data_t {
-         sbr_callback_data_t(const std::string &n, bool f, float cl, ProgressBarPopUp&& pp) : new_map_name(n), is_em_map_flag(f), contour_level(cl), popup(std::move(pp)) {}
+         sbr_callback_data_t(const std::string &n, bool f, bool dm, float cl, ProgressBarPopUp&& pp) : new_map_name(n), is_em_map_flag(f), is_diff_map_flag(dm), contour_level(cl), popup(std::move(pp)) {}
          std::string new_map_name;
          bool is_em_map_flag;
+         bool is_diff_map_flag;
          float contour_level;
          std::future<clipper::Xmap<float>> computation_result;
          ProgressBarPopUp popup;
       };
-      sbr_callback_data_t *sbrcd_p = new sbr_callback_data_t(map_name, is_em_map_flag, contour_level, ProgressBarPopUp("Sharpen Blur", "Computing..."));
+      sbr_callback_data_t *sbrcd_p = new sbr_callback_data_t(map_name, is_em_map_flag, is_diff_map_flag, contour_level, ProgressBarPopUp("Sharpen Blur", "Computing..."));
       sbrcd_p->computation_result = computation_result_promise.get_future();
 
       std::thread thread(sharpen_blur_inner, std::move(computation_result_promise), std::move(xmap), b_factor, resample_factor);
@@ -2856,7 +2861,8 @@ void sharpen_blur_map_with_resampling_threaded_version(int imol_map, float b_fac
             graphics_info_t g;
             int imol_new = g.create_molecule();
             auto result = sbrcd_p->computation_result.get();
-            g.molecules[imol_new].install_new_map(result, sbrcd_p->new_map_name, sbrcd_p->is_em_map_flag);
+            g.molecules[imol_new].install_new_map(result, sbrcd_p->new_map_name, sbrcd_p->is_em_map_flag,
+                                                  sbrcd_p->is_diff_map_flag);
             g.molecules[imol_new].set_contour_level(sbrcd_p->contour_level);
             g.set_imol_refinement_map(imol_new);
             graphics_draw();
@@ -2911,7 +2917,8 @@ void multi_sharpen_blur_map_scm(int imol_map, SCM b_factors_list_scm) {
 	       map_name += " Blur ";
 	    map_name += coot::util::float_to_string(b_factor);
 	    bool is_em_map_flag = graphics_info_t::molecules[imol_map].is_EM_map();
-	    g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag);
+	    bool is_diff_map_flag = graphics_info_t::molecules[imol_map].is_difference_map_p();
+	    g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag, is_diff_map_flag);
 	    graphics_info_t::molecules[imol_new].set_contour_level(contour_level*exp(-0.02*b_factor));
 	 }
 
@@ -2954,7 +2961,8 @@ void multi_sharpen_blur_map_py(int imol_map, PyObject *b_factors_list_py) {
 	       map_name += " Blur ";
 	    map_name += coot::util::float_to_string(b_factor);
 	    bool is_em_map_flag = graphics_info_t::molecules[imol_map].is_EM_map();
-	    g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag);
+	    bool is_diff_map_flag = graphics_info_t::molecules[imol_map].is_difference_map_p();
+	    g.molecules[imol_new].install_new_map(xmap_new, map_name, is_em_map_flag, is_diff_map_flag);
 	    graphics_info_t::molecules[imol_new].set_contour_level(contour_level*exp(-0.02*b_factor));
 	 }
       }
@@ -3193,7 +3201,8 @@ int flip_hand(int imol) {
       name += " Flipped Hand";
       float contour_level = graphics_info_t::molecules[imol].get_contour_level();
       bool is_em_flag = graphics_info_t::molecules[imol].is_EM_map();
-      graphics_info_t::molecules[imol_new].install_new_map(xmap, name, is_em_flag);
+      bool is_diff_map_flag = graphics_info_t::molecules[imol].is_difference_map_p();
+      graphics_info_t::molecules[imol_new].install_new_map(xmap, name, is_em_flag, is_diff_map_flag);
       graphics_info_t::molecules[imol_new].set_contour_level(contour_level);
       graphics_draw();
    }

--- a/src/graphics-info-state.cc
+++ b/src/graphics-info-state.cc
@@ -248,7 +248,7 @@ graphics_info_t::save_state_file(const std::string &filename, short int il) {
    int local_go_to_atom_mol = 0;
 
    // map sampling rate
-   if (map_sampling_rate != 1.5) { // only set it if it is not the default
+   if (map_sampling_rate != map_sampling_rate_default) { // only set it if it is not the default
       // command_strings.push_back("set-map-sampling-rate");
       // command_strings.push_back(float_to_string(map_sampling_rate));
       // commands.push_back(state_command("coot", command_strings, il));

--- a/src/graphics-info-statics.cc
+++ b/src/graphics-info-statics.cc
@@ -541,7 +541,7 @@ PyObject *graphics_info_t::post_intermediate_atoms_moved_hook = 0;
 #endif
 
 
-float graphics_info_t::map_sampling_rate = 2.5;
+float graphics_info_t::map_sampling_rate = graphics_info_t::map_sampling_rate_default;
 
 // Initialise the static atom_sel.
 //

--- a/src/graphics-info.h
+++ b/src/graphics-info.h
@@ -877,7 +877,11 @@ public:
    static float diff_map_iso_level_increment;
    static short int swap_difference_map_colours; // for Jan Dohnalek
 
-   static float map_sampling_rate; // Shannon sampling rate multiplier (1.5 default)
+   // Shannon sampling rate multiplier. Read only when a map is created from
+   // structure factors - changing it does not resample maps already loaded
+   // (use smooth_map() for that).
+   static constexpr float map_sampling_rate_default = 2.5;
+   static float map_sampling_rate;
 
    //
    static int control_is_pressed;

--- a/src/molecule-class-info-maps.cc
+++ b/src/molecule-class-info-maps.cc
@@ -2750,14 +2750,17 @@ molecule_class_info_t::set_map_has_symmetry(bool is_em_map) {
 
 
 void
-molecule_class_info_t::install_new_map(const clipper::Xmap<float> &map_in, std::string name_in, bool is_em_map_flag_in) {
+molecule_class_info_t::install_new_map(const clipper::Xmap<float> &map_in, std::string name_in, bool is_em_map_flag_in,
+                                       bool is_diff_map_flag_in) {
 
    xmap = map_in;
    if (is_em_map_flag_in)
       is_em_map_cached_flag = 1;
    // the map name is filled by using set_name(std::string)
    // sets name_ to name_in:
-   initialize_map_things_on_read_molecule(name_in, false, false, false); // not a diff_map
+   // 20260902-JD a map made from a difference map (resampled, sharpened, transformed...) is still a difference map 
+   initialize_map_things_on_read_molecule(name_in, is_diff_map_flag_in, false,
+                                          graphics_info_t::swap_difference_map_colours);
 
    // 20240702-PE now we can install empty maps (which get quickly overwritten by sensible maps)
    // (adding servalcat interface)
@@ -2771,12 +2774,20 @@ molecule_class_info_t::install_new_map(const clipper::Xmap<float> &map_in, std::
       float mean = mv.mean;
       float var = mv.variance;
 
-      contour_level  = nearest_step(mean + 1.5*sqrt(var), 0.05);
-      update_map_in_display_control_widget();
-
-      // fill class variables
+      // fill class variables (before the contour level, which is set from them)
       map_mean_ = mv.mean;
       map_sigma_ = sqrt(mv.variance);
+
+      if (is_diff_map_flag_in) {
+         // a difference map is contoured either side of zero, at a lower level:
+         // set_initial_contour_level() reads xmap_is_diff_map (set just above) and
+         // the mean/sigma to pick it.
+         set_initial_contour_level();
+      } else {
+         contour_level = nearest_step(mean + 1.5*sqrt(var), 0.05);
+      }
+      update_map_in_display_control_widget();
+
       if (is_em_map_flag_in)
          contour_sigma_step = 0.3; // 0.1 is the default
 

--- a/src/molecule-class-info.h
+++ b/src/molecule-class-info.h
@@ -1660,7 +1660,11 @@ public:        //                      public
 			  int swap_difference_map_colours_flag,
 			  float contour_level_in);
 
-   void install_new_map(const clipper::Xmap<float> &mapin, std::string name, bool is_em_map_in);
+   // is_diff_map_in: pass the source map's is_difference_map_p() when this map is derived
+   // from another one (resampling, sharpening, transforming), so the new map keeps its
+   // difference-map status, colours and contour level.
+   void install_new_map(const clipper::Xmap<float> &mapin, std::string name, bool is_em_map_in,
+                        bool is_diff_map_in = false);
 
    void install_new_map_with_contour_level(const clipper::Xmap<float> &mapin, std::string name, float contour_level, bool is_em_map_in);
 


### PR DESCRIPTION
## Description

- Added `smooth map` command
- Fix bug in map sampling where difference maps are forgotten