### PR TITLE
Restore backbone torsion editing lost during the GTK4 migration

### DIFF
--- a/src/c-interface.cc
+++ b/src/c-interface.cc
@@ -8529,6 +8529,7 @@ void setup_backbone_torsion_edit(short int state) {
    } else {
       g.in_backbone_torsion_define = state;
       if (state) {
+         g.add_status_bar_text("Edit Backbone Torsions: now click a backbone atom (N, CA, C or O)");
          std::cout << "click on an atom in the peptide to change" << std::endl;
          g.pick_cursor_maybe();
          g.pick_pending_flag = 1;

--- a/src/event-controller-callbacks.cc
+++ b/src/event-controller-callbacks.cc
@@ -563,6 +563,20 @@ graphics_info_t::on_glarea_click(GtkGestureClick *controller,
 
    SetMouseBegin(x,y);
 
+   // Picking is a click action, not a drag gesture (notably on macOS).
+   if (in_backbone_torsion_define) {
+      pick_info picked = atom_pick_gtk3(false);
+      if (picked.success == GL_TRUE) {
+         in_backbone_torsion_define = 0;
+         pick_pending_flag = 0;
+         normal_cursor();
+         execute_setup_backbone_torsion_edit(picked.imol, picked.atom_index);
+      } else {
+         add_status_bar_text("Edit Backbone Torsions: click a backbone atom (N, CA, C or O)");
+      }
+      return;
+   }
+
    bool clicked = check_if_hud_bar_clicked(x,y);
 
    // std::cout << "status for HUD bar clicked: " << clicked << " x " << x << " y " << y << std::endl;

--- a/src/gl-rama-plot.hh
+++ b/src/gl-rama-plot.hh
@@ -143,6 +143,14 @@ public:
    void set_rama_plot_scale(float rs) { rama_plot_scale = rs; }
 
    void setup_from(int imol, mmdb::Manager *mol, const std::string &residue_selection, draw_mode_t draw_mode);
+   // The caller owns angle calculation; use the same renderer/classification.
+   // Like setup_from(), call with the plot's GL context current.
+   void setup_from_phi_psis(const std::map<coot::residue_spec_t, rama_plot::phi_psi_t> &points) {
+      phi_psi_map = points;
+      update_hud_tmeshes(phi_psi_map);
+      residue_selection.clear(); // invalidate setup_from()'s molecular cache
+      have_current_residue_marker = false;
+   }
    void update_phi_psis_on_moved_atoms();
    // void background_to_type(GtkWidget *canvas, clipper::Ramachandran::TYPE); // don't change it if we are already there of course.
    void draw(Shader *shader_for_axes_and_tick,

--- a/src/glade-callbacks-main-window.cc
+++ b/src/glade-callbacks-main-window.cc
@@ -210,6 +210,13 @@ on_model_toolbar_edit_chi_angles_button_clicked(GtkButton *button,
    }
 }
 
+extern "C" G_MODULE_EXPORT
+void
+on_model_toolbar_edit_backbone_torsions_button_clicked(GtkButton *button,
+                                                       gpointer   user_data) {
+   setup_backbone_torsion_edit(1);
+}
+
 
 
 extern "C" G_MODULE_EXPORT

--- a/src/glade-callbacks.cc
+++ b/src/glade-callbacks.cc
@@ -2499,7 +2499,7 @@ void
 on_edit_backbone_torsions_dialog_destroy(GtkWidget       *object,
                                         gpointer         user_data) {
 
-   clear_moving_atoms_object();
+   clear_up_moving_atoms();
   /* FIXME: also clear out the edib backbone ramaplot, if it exists. */
   /*   destroy_edit_backbone_rama_plot(); */
 }
@@ -2526,10 +2526,8 @@ on_edit_backbone_torsion_cancel_button_clicked
                                         gpointer         user_data)
 {
    GtkWidget *window = widget_from_builder("edit_backbone_torsions_dialog");
-   /*   clear_moving_atoms_object(); done as part of window destroy
-        callback */
+   clear_up_moving_atoms();
    destroy_edit_backbone_rama_plot(); // 20211006-PE this function name should be changed
-   //gtk_widget_set_visible(window, FALSE);
    gtk_widget_set_visible(window, FALSE);
 
 }

--- a/src/graphics-info-defines.cc
+++ b/src/graphics-info-defines.cc
@@ -64,6 +64,7 @@ graphics_info_t::clear_pending_picks() {
    in_auto_fit_define = 0;
    in_db_main_define           = 0;
    in_edit_phi_psi_define      = 0;
+   in_backbone_torsion_define  = 0;
    in_add_alt_conf_define      = 0;
    in_save_symmetry_define     = 0;
    in_cis_trans_convert_define = 0;

--- a/src/graphics-info-draw.cc
+++ b/src/graphics-info-draw.cc
@@ -3389,13 +3389,35 @@ graphics_info_t::draw_hud_ramachandran_plot() {
    int w = allocation.width;
    int h = allocation.height;
 
-   if (draw_gl_ramachandran_plot_flag) {
-      if (draw_gl_ramachandran_plot_user_control_flag) {
+   if (draw_gl_ramachandran_plot_flag || backbone_torsion_rama_active) {
+      if (draw_gl_ramachandran_plot_user_control_flag || backbone_torsion_rama_active) {
          if (moving_atoms_asc) {
             if (moving_atoms_asc->n_selected_atoms > 0) {
                std::string residue_selection = "//";
                gl_rama_plot_t::draw_mode_t draw_mode = gl_rama_plot_t::draw_mode_t::DRAW_MODE;
-               gl_rama_plot.setup_from(imol_moving_atoms, moving_atoms_asc->mol, residue_selection, draw_mode); // checks to see if an update is acutally needed.
+               if (backbone_torsion_rama_active) {
+                  graphics_info_t g;
+                  const auto pairs = g.phi_psi_pairs_from_moving_atoms();
+                  std::map<coot::residue_spec_t, rama_plot::phi_psi_t> points;
+                  auto add_point = [&points] (mmdb::Atom *atom, const std::pair<double, double> &angles) {
+                     if (atom && angles.first > -200) { // existing invalid-angle sentinel
+                        auto *residue = atom->GetResidue();
+                        coot::residue_spec_t spec(residue);
+                        rama_plot::phi_psi_t point(clipper::Util::rad2d(angles.first),
+                                                   clipper::Util::rad2d(angles.second));
+                        point.residue_name = residue->GetResName();
+                        point.chain_id = residue->GetChainID();
+                        point.res_no = residue->GetSeqNum();
+                        point.ins_code = residue->GetInsCode();
+                        points.emplace(spec, point);
+                     }
+                  };
+                  add_point(coot::get_first_atom_with_atom_name(" C  ", *moving_atoms_asc), pairs.first);
+                  add_point(coot::get_first_atom_with_atom_name(" N  ", *moving_atoms_asc), pairs.second);
+                  gl_rama_plot.setup_from_phi_psis(points);
+               } else {
+                  gl_rama_plot.setup_from(imol_moving_atoms, moving_atoms_asc->mol, residue_selection, draw_mode);
+               }
                // no context switch needed for the HUD Rama plot
                bool clear_needed_flag = false;
                gl_rama_plot.draw(&shader_for_rama_plot_axes_and_ticks,

--- a/src/graphics-info-gui.cc
+++ b/src/graphics-info-gui.cc
@@ -2813,15 +2813,13 @@ graphics_info_t::execute_setup_backbone_torsion_edit(int imol, int atom_index) {
 // 		  std::cout << "DEBUG:: backbone_torsion_end_ca_2: "
 // 			    << backbone_torsion_end_ca_2.format() << std::endl;
 
+          backbone_torsion_rama_active = true;
 		  graphics_draw();
 		  // GtkWidget *widget = create_edit_backbone_torsions_dialog();
 		  GtkWidget *widget = widget_from_builder("edit_backbone_torsions_dialog");
 		  set_edit_backbone_adjustments(widget);
-		  gtk_widget_set_visible(widget, TRUE);
-        // update the graph to show both
-        GtkWidget *adj;
-        adj = widget_from_builder("edit_backbone_torsions_rotate_carbonyl_adjustment");
-        g_signal_emit_by_name(G_OBJECT(adj), "value_changed");
+          set_transient_for_main_window(widget);
+          gtk_window_present(GTK_WINDOW(widget));
 
 	       } else {
 		  std::cout << "WARNING:: not all atoms found in "
@@ -2872,8 +2870,6 @@ graphics_info_t::set_edit_backbone_adjustments(GtkWidget *widget) {
 void
 graphics_info_t::edit_backbone_peptide_changed_func(GtkAdjustment *adj, GtkWidget *window) {
 
-#ifdef HAVE_GOOCANVAS
-
    graphics_info_t g;
    // std::cout << "change backbone peptide by: " << adj->value << std::endl;
 
@@ -2911,6 +2907,7 @@ graphics_info_t::edit_backbone_peptide_changed_func(GtkAdjustment *adj, GtkWidge
       o_atom_p->y = new_o.y();
       o_atom_p->z = new_o.z();
 
+#ifdef DO_RAMA_PLOT
       std::pair<std::pair<double, double>, std::pair<double, double> > pp =
 	 g.phi_psi_pairs_from_moving_atoms();
 
@@ -2939,10 +2936,10 @@ graphics_info_t::edit_backbone_peptide_changed_func(GtkAdjustment *adj, GtkWidge
 	 if (vp.size() > 0)
 	    edit_phi_psi_plot->draw_it(vp);
       }
+#endif
 
       regularize_object_bonds_box.clear_up();
-      int imol = 0; // should be fine for backbone edits
-      g.make_moving_atoms_graphics_object(imol, *moving_atoms_asc);
+      g.make_moving_atoms_graphics_object(imol_moving_atoms, *moving_atoms_asc);
       graphics_draw();
 
    } else {
@@ -2950,14 +2947,11 @@ graphics_info_t::edit_backbone_peptide_changed_func(GtkAdjustment *adj, GtkWidge
 		<< std::endl;
    }
 
-#endif
 }
 
 // static
 void
 graphics_info_t::edit_backbone_carbonyl_changed_func(GtkAdjustment *adj, GtkWidget *window) {
-
-#ifdef HAVE_GOOCANVAS
    graphics_info_t g;
    // std::cout << "change backbone peptide by: " << adj->value << std::endl;
 
@@ -2989,6 +2983,7 @@ graphics_info_t::edit_backbone_carbonyl_changed_func(GtkAdjustment *adj, GtkWidg
       o_atom_p->y = new_o.y();
       o_atom_p->z = new_o.z();
 
+#ifdef DO_RAMA_PLOT
       std::pair<std::pair<double, double>, std::pair<double, double> > pp =
 	 g.phi_psi_pairs_from_moving_atoms();
 
@@ -3024,11 +3019,11 @@ graphics_info_t::edit_backbone_carbonyl_changed_func(GtkAdjustment *adj, GtkWidg
 	 if (vp.size() > 0)
 	    edit_phi_psi_plot->draw_it(vp);
       }
+#endif
 
 
       regularize_object_bonds_box.clear_up();
-      int imol = 0; // should be fine for backbone edits
-      g.make_moving_atoms_graphics_object(imol, *moving_atoms_asc);
+      g.make_moving_atoms_graphics_object(imol_moving_atoms, *moving_atoms_asc);
       graphics_draw();
 
    } else {
@@ -3036,7 +3031,6 @@ graphics_info_t::edit_backbone_carbonyl_changed_func(GtkAdjustment *adj, GtkWidg
 		<< std::endl;
    }
 
-#endif
 }
 
 
@@ -3045,8 +3039,6 @@ graphics_info_t::edit_backbone_carbonyl_changed_func(GtkAdjustment *adj, GtkWidg
 // Tinker with the moving atoms
 void
 graphics_info_t::change_peptide_carbonyl_by(double angle) {
-
-#ifdef HAVE_GOOCANVAS
 
 //    std::cout << "move carbonyl by " << angle << std::endl;
    mmdb::Atom *n_atom_p = coot::get_first_atom_with_atom_name(" N  ", *moving_atoms_asc);
@@ -3076,6 +3068,7 @@ graphics_info_t::change_peptide_carbonyl_by(double angle) {
    o_atom_p->y = new_o.y();
    o_atom_p->z = new_o.z();
 
+#ifdef DO_RAMA_PLOT
    std::pair<std::pair<double, double>, std::pair<double, double> > pp =
       phi_psi_pairs_from_moving_atoms();
 
@@ -3101,14 +3094,13 @@ graphics_info_t::change_peptide_carbonyl_by(double angle) {
       vp.push_back(phipsi2);
       edit_phi_psi_plot->draw_it(vp);
    }
+#endif
 
 
    regularize_object_bonds_box.clear_up();
-   int imol = 0; // should be fine for backbone edits
-   make_moving_atoms_graphics_object(imol, *moving_atoms_asc);
+   make_moving_atoms_graphics_object(imol_moving_atoms, *moving_atoms_asc);
    graphics_draw();
 
-#endif // HAVE_GOOCANVAS
 }
 
 
@@ -3178,8 +3170,6 @@ graphics_info_t::phi_psi_pairs_from_moving_atoms() {
 void
 graphics_info_t::change_peptide_peptide_by(double angle) {
 
-#ifdef HAVE_GOOCANVAS
-
    //    std::cout << "move peptide by " << angle << std::endl;
 
    mmdb::Atom *n_atom_p = coot::get_first_atom_with_atom_name(" N  ", *moving_atoms_asc);
@@ -3218,13 +3208,12 @@ graphics_info_t::change_peptide_peptide_by(double angle) {
    o_atom_p->y = new_o.y();
    o_atom_p->z = new_o.z();
 
+#ifdef DO_RAMA_PLOT
    std::pair<std::pair<double, double>, std::pair<double, double> > pp =
       phi_psi_pairs_from_moving_atoms();
 
 //    std::cout << pp.first.first  << " " << pp.first.second << "      "
 // 	     << pp.second.first << " " << pp.second.second << std::endl;
-
-#ifdef DO_RAMA_PLOT
 
    if (edit_phi_psi_plot) {
       std::vector <coot::util::phi_psi_t> vp;
@@ -3247,11 +3236,9 @@ graphics_info_t::change_peptide_peptide_by(double angle) {
 
 
    regularize_object_bonds_box.clear_up();
-   int imol = 0; // should be fine for backbone edits
-   make_moving_atoms_graphics_object(imol, *moving_atoms_asc);
+   make_moving_atoms_graphics_object(imol_moving_atoms, *moving_atoms_asc);
    graphics_draw();
 
-#endif // HAVE_GOOCANVAS
 }
 
 

--- a/src/graphics-info.cc
+++ b/src/graphics-info.cc
@@ -2115,6 +2115,7 @@ graphics_info_t::update_environment_distances_by_rotation_centre_maybe(int imol_
 
 void
 graphics_info_t::clear_up_moving_atoms() {
+   backbone_torsion_rama_active = false;
 
    // this function is not just graphics, so it needs to check use_graphics_interface_flag
    // internally.
@@ -4835,6 +4836,8 @@ graphics_info_t::rama_plot_for_2_phi_psis(int imol, int atom_index) {
 void
 graphics_info_t::destroy_edit_backbone_rama_plot() {  // only one of these.
 
+   backbone_torsion_rama_active = false;
+   graphics_draw();
 }
 
 

--- a/src/graphics-info.h
+++ b/src/graphics-info.h
@@ -4273,6 +4273,7 @@ string   static std::string sessionid;
 
    static gl_rama_plot_t gl_rama_plot;
    static void draw_hud_ramachandran_plot(); // OpenGL rama plot
+   inline static bool backbone_torsion_rama_active = false;
    void clear_gl_rama_plot();  // why not static also?
    static bool draw_gl_ramachandran_plot_flag;    // used for RSR vs translation or rotamers
    static bool draw_gl_ramachandran_plot_user_control_flag; // used for user not wanting to see it during RSR

--- a/ui/coot.ui
+++ b/ui/coot.ui
@@ -4845,7 +4845,7 @@ that you wish to delete.               </property>
               <object class="GtkBox" id="hbox67">
                 <child>
                   <object class="GtkButton" id="edit_backbone_torsion_ok_button">
-                    <property name="label" translatable="yes">  OK  </property>
+                    <property name="label" translatable="yes">  Accept  </property>
                     <property name="can-focus">1</property>
                     <property name="use-underline">1</property>
                     <signal name="clicked" handler="on_edit_backbone_torsion_ok_button_clicked" swapped="no"/>
@@ -4885,7 +4885,7 @@ that you wish to delete.               </property>
                 <child>
                   <object class="GtkFrame" id="frame83">
                     <child>
-                      <object class="GtkScale">
+                      <object class="GtkScale" id="edit_backbone_torsions_rotate_carbonyl_hscale">
                         <property name="can-focus">1</property>
                         <property name="round-digits">1</property>
                       </object>
@@ -4895,11 +4895,6 @@ that you wish to delete.               </property>
                         <property name="label" translatable="yes">Rotate Carbonyl</property>
                       </object>
                     </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="label" translatable="yes">[Add back the callbacks for value change]</property>
                   </object>
                 </child>
               </object>
@@ -11315,6 +11310,28 @@ Do you want to continue?
                 </child>
                 <property name="can-focus">0</property>
                 <signal name="clicked" handler="on_model_toolbar_edit_chi_angles_button_clicked"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="vertical_toolbar_edit_backbone_torsions_button">
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">edit-backbone</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">Edit Backbone Torsions</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <property name="can-focus">0</property>
+                <signal name="clicked" handler="on_model_toolbar_edit_backbone_torsions_button_clicked"/>
               </object>
             </child>
             <child>


### PR DESCRIPTION
This PR restores the backbone torsion editing workflow that was available before the GTK4 migration but is currently inaccessible in the GTK4 UI.

The existing underlying torsion-editing code is still present, but parts of the workflow remained tied to the old GooCanvas/GTK implementation. This patch reconnects that existing functionality to the current GTK4 picking and OpenGL Ramachandran infrastructure.

Specifically, it restores:

- toolbar access to Edit Backbone Torsions
- GTK4 atom picking
- the existing backbone torsion dialog and controls
- live coordinate rotation while dragging the sliders
- live Ramachandran feedback using the existing OpenGL Rama renderer
- correct Accept/Cancel and repeated-use cleanup

This is intended as a regression restoration rather than a new feature.

It does **not** restore GooCanvas, and it does not change phi/psi calculation, Ramachandran classification thresholds, or colouring algorithms.

## Validation

Tested with a clean macOS build and independent installation.

Verified:

- atom picking
- physical slider dragging
- live coordinate updates
- live Rama feedback
- Accept/Cancel
- repeated use without stale state
- Real Space Refine Rama HUD still operates normally
- Torsion General / Edit Chi basic smoke tests